### PR TITLE
Fix: Correct Tailwind CSS configuration and dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   "dependencies": {
     "framer-motion": "^10.16.4",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0",
-    "tailwind": "^4.0.0"
+    "react-dom": "^18.2.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.15",

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};


### PR DESCRIPTION
This commit addresses issues preventing Tailwind CSS from working correctly.

Changes include:
- Removed an incorrect "tailwind": "^4.0.0" dependency from package.json. The correct package is "tailwindcss".
- Added a `postcss.config.cjs` file with explicit configuration for tailwindcss and autoprefixer. The .cjs extension is used because the project has "type": "module" in package.json.

IMPORTANT: Due to limitations in the execution environment, `npm install` was not run. You must run `npm install` locally after pulling these changes to update dependencies (including `tailwindcss-animate` and others) and regenerate the `package-lock.json` file.

After running `npm install`, Tailwind CSS should function as expected.